### PR TITLE
registry: move to canonical location

### DIFF
--- a/cmd/otto/main.go
+++ b/cmd/otto/main.go
@@ -17,6 +17,7 @@ import (
 
 	_ "crypto/sha512"
 
+	"github.com/gicmo/otto/internal/registry"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	digest "github.com/opencontainers/go-digest"
@@ -95,13 +96,13 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 type Server struct {
 	root string
 
-	oci *Registry
+	oci *registry.Registry
 }
 
 func NewServer(root string) *Server {
 	return &Server{
 		root: root,
-		oci:  NewRegistry(filepath.Join(root, "oci")),
+		oci:  registry.NewRegistry(filepath.Join(root, "oci")),
 	}
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,4 +1,4 @@
-package main
+package registry
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Internal libraries live in internal/

Signed-off-by: Tom Gundersen <teg@jklm.no>